### PR TITLE
fix(WebVaultClient): Sync before emitting login event

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -251,6 +251,7 @@ class WebVaultClient {
   async login(masterPassword) {
     await this.initFinished
     const login = await this.authService.logIn(this.email, masterPassword)
+    await this.sync()
     this.emit('login', this)
     return login
   }
@@ -269,7 +270,6 @@ class WebVaultClient {
     const storedKeyHash = await this.cryptoService.getKeyHash()
     if (!isAuthed || !kdf || !storedKeyHash) {
       await this.login(masterPassword)
-      this.sync()
     } else {
       const key = await this.cryptoService.makeKey(
         masterPassword,


### PR DESCRIPTION
We had to put a `vaultClient.sync()` after login in cozy-harvest-lib. Removing it caused the following error:

```js
TypeError: "eqDomains is null"
    eqDomainsPromise cipher.service.js:678
```

This means that we were not doing the `sync` at the good time.

I tried

```js
await this.login(masterPassword)
await this.sync()
```

But it didn't work. The only thing that succeeds was to do `await this.sync()` before emitting the `login` event.