### PR TITLE
Storage singleton

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -535,67 +535,6 @@ class WebVaultClient {
       : this.cryptoService.getEncKey())
     return this.cipherService.encrypt(decryptedData, key, originalCipher)
   }
-
-  /**
-   * First step to change email
-   * Will send a token to the user in its email box
-   * @param {string} email
-   * @param {string} masterPassword
-   * @see https://github.com/bitwarden/web/blob/master/src/app/settings/change-email.component.ts
-   */
-  async changeEmailRequest(email, masterPassword) {
-    /* eslint-disable no-unreachable */
-    throw 'Email is generated, you should never change it'
-    await this.initFinished
-    const newEmail = email.trim().toLowerCase()
-    const request = new EmailTokenRequest()
-    request.newEmail = newEmail
-    request.masterPasswordHash = await this.cryptoService.hashPassword(
-      masterPassword,
-      null
-    )
-    await this.apiService.postEmailToken(request)
-  } /* eslint-enable no-unreachable */
-
-  /**
-   * Second step to change email
-   * Will encrypt the master key with the new master password and save the vault
-   * @param {string} email
-   * @param {string} masterPassword
-   * @param {string} token - from `changeEmailRequest()`
-   * @see https://github.com/bitwarden/web/blob/master/src/app/settings/change-email.component.ts
-   */
-  async changeEmail(email, masterPassword, token) {
-    /* eslint-disable no-unreachable */
-    throw 'Email is generated, you should never change it'
-    await this.initFinished
-    const newEmail = email.trim().toLowerCase()
-    const request = new EmailRequest()
-    request.token = token
-    request.newEmail = newEmail
-    request.masterPasswordHash = await this.cryptoService.hashPassword(
-      masterPassword,
-      null
-    )
-    const kdf = await this.userService.getKdf()
-    const kdfIterations = await this.userService.getKdfIterations()
-    const newKey = await this.cryptoService.makeKey(
-      masterPassword,
-      newEmail,
-      kdf,
-      kdfIterations
-    )
-    request.newMasterPasswordHash = await this.cryptoService.hashPassword(
-      masterPassword,
-      newKey
-    )
-    const newEncKey = await this.cryptoService.remakeEncKey(newKey)
-    request.key = newEncKey[1].encryptedString
-    await this.apiService.postEmail(request)
-    this.email = email
-    await this.login(masterPassword)
-    await this.sync()
-  } /* eslint-enable no-unreachable */
 }
 
 MicroEE.mixin(WebVaultClient)

--- a/src/WebVaultClient.spec.js
+++ b/src/WebVaultClient.spec.js
@@ -1,6 +1,48 @@
 import WebVaultClient from './WebVaultClient'
+import { Utils } from './@bitwarden/jslib/misc/utils'
+
+jest.mock('./@bitwarden/jslib/misc/utils', () => {
+  return {
+    Utils: {
+      init: jest.fn(),
+      global: {}
+    }
+  }
+})
 
 describe('WebVaultClient', () => {
+  describe('global instance', () => {
+    it('should set the global container service variable', () => {
+      const client = new WebVaultClient('https://me.cozy.wtf')
+      expect(Utils.global.bitwardenContainerService).toBe(
+        client.containerService
+      )
+    })
+
+    it('should update the global container service variable when a new instance is created', () => {
+      const client1 = new WebVaultClient('https://me.cozy.wtf')
+      expect(Utils.global.bitwardenContainerService).toBe(
+        client1.containerService
+      )
+      const client2 = new WebVaultClient('https://myoue.cozy.wtf')
+      expect(Utils.global.bitwardenContainerService).toBe(
+        client2.containerService
+      )
+    })
+
+    it('should attach the current instances container service to the global context', () => {
+      const client1 = new WebVaultClient('https://me.cozy.wtf')
+      const client2 = new WebVaultClient('https://myoue.cozy.wtf')
+      expect(Utils.global.bitwardenContainerService).toBe(
+        client2.containerService
+      )
+      client1.attachToGlobal()
+      expect(Utils.global.bitwardenContainerService).toBe(
+        client1.containerService
+      )
+    })
+  })
+
   describe('weakMatch', () => {
     let client
     beforeAll(() => {


### PR DESCRIPTION
The bitwarden lib uses a global variable that contains the decryption key.

We had a bug where, if multiple vault client instances were created, the first one would set the global variable, and all other ones would start using that global variable. If the first client wasn't logged in, all other clients would fail to decrypt data because there was no key to use.

There are legitimate use cases for creating multiple client instances over the lifetime of a page.

The fix proposed here is to make sure the global variable is always bound to the correct instance before attempting any crypto operations.