### PR TITLE
refactor: share with cozy only when not already in cozy org

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -481,9 +481,13 @@ class WebVaultClient {
   async shareWithCozy(cipherView) {
     this.attachToGlobal()
     const org = await this.getCozyOrg()
-    const cols = await this.getCollectionsForOrg(org)
-    const colIds = cols.map(col => col.id)
-    return this.cipherService.shareWithServer(cipherView, org.id, colIds)
+    if (cipherView.organizationId != org.id) {
+      const cols = await this.getCollectionsForOrg(org)
+      const colIds = cols.map(col => col.id)
+      return this.cipherService.shareWithServer(cipherView, org.id, colIds)
+    } else {
+      return undefined
+    }
   }
 
   /**


### PR DESCRIPTION
Do not try to write a share if the cipher is already shared