### PR TITLE
Bundle size optimizations

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,6 +25,10 @@ module.exports = {
               {
                 pattern: '^sweetalert',
                 location: path.resolve(__dirname, 'src/stubs/null.js')
+              },
+              {
+                pattern: '^node-forge$',
+                location: path.resolve(__dirname, 'src/stubs/node-forge.js')
               }
             ]
           }

--- a/babel.config.js
+++ b/babel.config.js
@@ -27,6 +27,10 @@ module.exports = {
                 location: path.resolve(__dirname, 'src/stubs/null.js')
               },
               {
+                pattern: 'misc/wordlist$',
+                location: path.resolve(__dirname, 'src/stubs/null.js')
+              },
+              {
                 pattern: '^node-forge$',
                 location: path.resolve(__dirname, 'src/stubs/node-forge.js')
               }

--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,10 @@ module.exports = {
               {
                 pattern: '^zxcvbn$',
                 location: path.resolve(__dirname, 'src/stubs/null.js')
+              },
+              {
+                pattern: '^tldjs$',
+                location: path.resolve(__dirname, 'src/stubs/null.js')
               }
             ]
           }

--- a/babel.config.js
+++ b/babel.config.js
@@ -21,6 +21,10 @@ module.exports = {
               {
                 pattern: '^tldjs$',
                 location: path.resolve(__dirname, 'src/stubs/null.js')
+              },
+              {
+                pattern: '^sweetalert',
+                location: path.resolve(__dirname, 'src/stubs/null.js')
               }
             ]
           }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 module.exports = {
   presets: ['cozy-app'],
   ignore: ['*.spec.js', '*.spec.jsx'],
@@ -7,7 +9,18 @@ module.exports = {
       plugins: [
         '@babel/plugin-proposal-export-default-from',
         '@babel/plugin-proposal-export-namespace-from',
-        'inline-react-svg'
+        'inline-react-svg',
+        [
+          'mock-imports',
+          {
+            redirects: [
+              {
+                pattern: '^zxcvbn$',
+                location: path.resolve(__dirname, 'src/stubs/null.js')
+              }
+            ]
+          }
+        ]
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@semantic-release/npm": "^5.1.15",
     "babel-loader": "^8.0.6",
     "babel-plugin-inline-react-svg": "^1.1.0",
+    "babel-plugin-mock-imports": "^1.0.2",
     "babel-plugin-rewire": "1.2.0",
     "babel-preset-cozy-app": "^1.6.0",
     "enzyme": "^3.10.0",

--- a/src/stubs/node-forge.js
+++ b/src/stubs/node-forge.js
@@ -1,0 +1,8 @@
+module.exports = require('node-forge/lib/forge')
+require('node-forge/lib/asn1')
+require('node-forge/lib/cipher')
+require('node-forge/lib/hmac')
+require('node-forge/lib/md')
+require('node-forge/lib/pbkdf2')
+require('node-forge/lib/pki')
+require('node-forge/lib/util')

--- a/src/stubs/null.js
+++ b/src/stubs/null.js
@@ -1,0 +1,1 @@
+export default null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,6 +1949,11 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-mock-imports@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-mock-imports/-/babel-plugin-mock-imports-1.0.2.tgz#c096e61e2b635ef348528ae387bda35477c6a7b1"
+  integrity sha512-QMVumiK+Z1yvA74IUsQGKx/XyZ6mKW7YNrEucDGbnWZU1RA/TjyBAwc86xHgkNVy4853jOWdjZY+/5l5bZ7lPQ==
+
 babel-plugin-rewire@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz#822562d72ed2c84e47c0f95ee232c920853e9d89"


### PR DESCRIPTION
Our bundle was pretty large. By mapping some unused modules to `null` or reduced versions, we can optimize it a little.

| | Original | Step 1 : -zxcvbn | Step 2 : -tldjs | Step 3 : -sweetalert | Step 4 : -unused node-forge parts |Reduction|
|-|----------|---------|--------|-------------|--------------------------|---|
|Stats size|2.93 MB|2.12 MB|1.96 MB|1.92 MB|1.66MB|-43%|
|Parsed size|1.68 MB|920.68 KB|773.59 KB|734.13 KB|648.52 KB|-61%|
|Gzipped size|619.08 KB|232.04 KB|197.59 KB|187.03 KB|163.36 KB|-73%|