### PR TITLE
fix: Use relative path for import redirects

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,23 +16,23 @@ module.exports = {
             redirects: [
               {
                 pattern: '^zxcvbn$',
-                location: path.resolve(__dirname, 'src/stubs/null.js')
+                location: '../../../stubs/null.js'
               },
               {
                 pattern: '^tldjs$',
-                location: path.resolve(__dirname, 'src/stubs/null.js')
+                location: '../../../stubs/null.js'
               },
               {
                 pattern: '^sweetalert',
-                location: path.resolve(__dirname, 'src/stubs/null.js')
+                location: './stubs/null.js'
               },
               {
                 pattern: 'misc/wordlist$',
-                location: path.resolve(__dirname, 'src/stubs/null.js')
+                location: '../../../stubs/null.js'
               },
               {
                 pattern: '^node-forge$',
-                location: path.resolve(__dirname, 'src/stubs/node-forge.js')
+                location: '../../../stubs/node-forge.js'
               }
             ]
           }


### PR DESCRIPTION
When using absolute paths, the paths generated on travis are used in the
module published on npm, so everything breaks. We get errors like `Error: Can't resolve '/home/travis/build/cozy/cozy-keys-lib/src/stubs/node-forge.js'`. Using relative paths fixes this.