### PR TITLE
fix(UnlockForm): The cancel button should be of type button

### DIFF
--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -103,6 +103,7 @@ class UnlockForm extends React.Component {
               onClick={onDismiss}
               label={t('unlock.abort')}
               className="u-mr-half u-w-100-t"
+              type="button"
             />
             <Button
               label={t('unlock.unlock')}


### PR DESCRIPTION
By default, the button is of type submit. But it should not trigger the
form submit when clicking on it or typing on the enter key. Settings its
type to button fixes the problem.