### PR TITLE
feat: Make unlock form closable

### DIFF
--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -47,7 +47,7 @@ class UnlockForm extends React.Component {
   }
 
   render() {
-    const { t, onDismiss } = this.props
+    const { t, onDismiss, closable } = this.props
     const { password, error, unlocking } = this.state
     return (
       <Modal
@@ -55,6 +55,7 @@ class UnlockForm extends React.Component {
         className="u-bg-primaryColor"
         closeBtnColor={palette['white']}
         dismissAction={onDismiss}
+        closable={closable}
       >
         <form
           onSubmit={this.handleVaultUnlock}
@@ -121,7 +122,12 @@ class UnlockForm extends React.Component {
 UnlockForm.propTypes = {
   vaultClient: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  onDismiss: PropTypes.func.isRequired
+  onDismiss: PropTypes.func.isRequired,
+  closable: PropTypes.bool
+}
+
+UnlockForm.defaultProps = {
+  closable: true
 }
 
 export default withVaultClient(translate()(UnlockForm))

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -10,9 +10,13 @@ const locales = {
   fr: localesFr
 }
 
-const VaultUnlocker = ({ children, onDismiss }) => {
+const VaultUnlocker = ({ children, onDismiss, closable }) => {
   const { locked } = React.useContext(VaultContext)
-  return locked ? <UnlockForm onDismiss={onDismiss} /> : children
+  return locked ? (
+    <UnlockForm onDismiss={onDismiss} closable={closable} />
+  ) : (
+    children
+  )
 }
 
 export default withLocales(locales)(VaultUnlocker)


### PR DESCRIPTION
In some context, like intents modals, there is already a close cross to
close the modal, so we don't want to render the unlock form cross. To
achieve that we use the Modal's closable prop.