### PR TITLE
Consider an empty vault as unlocked

### DIFF
--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -82,7 +82,10 @@ class UnlockForm extends React.Component {
     this.setState({ unlocking: true, error: null })
     try {
       await vaultClient.unlock(this.state.password)
-      onUnlock()
+
+      if (onUnlock) {
+        onUnlock()
+      }
     } catch (error) {
       this.setState({ error })
     } finally {
@@ -170,7 +173,8 @@ UnlockForm.propTypes = {
   t: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
   closable: PropTypes.bool,
-  client: PropTypes.object.isRequired
+  client: PropTypes.object.isRequired,
+  onUnlock: PropTypes.func
 }
 
 UnlockForm.defaultProps = {

--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -78,10 +78,11 @@ class UnlockForm extends React.Component {
   }
 
   async unlockVault() {
-    const { vaultClient } = this.props
+    const { vaultClient, onUnlock } = this.props
     this.setState({ unlocking: true, error: null })
     try {
       await vaultClient.unlock(this.state.password)
+      onUnlock()
     } catch (error) {
       this.setState({ error })
     } finally {

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -10,10 +10,10 @@ const locales = {
   fr: localesFr
 }
 
-const VaultUnlocker = ({ children, onDismiss, closable }) => {
+const VaultUnlocker = ({ children, onDismiss, closable, onUnlock }) => {
   const { locked } = React.useContext(VaultContext)
   return locked ? (
-    <UnlockForm onDismiss={onDismiss} closable={closable} />
+    <UnlockForm onDismiss={onDismiss} closable={closable} onUnlock={onUnlock} />
   ) : (
     children
   )

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -1,22 +1,73 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { VaultContext } from './VaultContext'
 import UnlockForm from './UnlockForm'
 import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
 import localesEn from '../locales/en.json'
 import localesFr from '../locales/fr.json'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { withClient } from 'cozy-client'
 
 const locales = {
   en: localesEn,
   fr: localesFr
 }
 
-const VaultUnlocker = ({ children, onDismiss, closable, onUnlock }) => {
+const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
+
+const VaultUnlocker = ({
+  children,
+  onDismiss,
+  closable,
+  onUnlock,
+  client: cozyClient
+}) => {
+  const [isCheckingCiphers, setIsCheckingCiphers] = useState(true)
+  const [hasCiphers, setHasCiphers] = useState(false)
+
   const { locked } = React.useContext(VaultContext)
-  return locked ? (
+
+  useEffect(() => {
+    const checkCiphers = async () => {
+      try {
+        const { data } = await cozyClient.query(
+          cozyClient.find(CIPHERS_DOCTYPE).where({ shared_with_cozy: true })
+        )
+
+        const hasCiphers = data.length > 0
+
+        setHasCiphers(hasCiphers)
+
+        // If there is no cipher in the vault, it means the user never used it,
+        // so we don't force them to unlock it for nothing
+        if (!hasCiphers && onUnlock) {
+          onUnlock()
+        }
+      } catch (err) {
+        /* eslint-disable no-console */
+        console.error(`Error while fetching ${CIPHERS_DOCTYPE}:`)
+        console.error(err)
+        /* eslint-enable no-console */
+      } finally {
+        setIsCheckingCiphers(false)
+      }
+    }
+
+    checkCiphers()
+  }, [])
+
+  if (isCheckingCiphers) {
+    return (
+      <div className="u-ta-center">
+        <Spinner size="xxlarge" />
+      </div>
+    )
+  }
+
+  return locked && hasCiphers ? (
     <UnlockForm onDismiss={onDismiss} closable={closable} onUnlock={onUnlock} />
   ) : (
     children
   )
 }
 
-export default withLocales(locales)(VaultUnlocker)
+export default withLocales(locales)(withClient(VaultUnlocker))


### PR DESCRIPTION
We consider a user doesn't use the password manager feature as long as he
doesn't have any cipher. In that case, we don't want him to unlock his
empty unused vault. So we consider that an empty vault as always unlocked.
When the user uses the Cozy web browser extension for the first time, his
existing accounts will be added to its vault, then we will consider that he
is using the vault.