### PR TITLE
Update auto unlock condition

### DIFF
--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -14,6 +14,21 @@ const locales = {
 
 const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
 
+const checkHasCiphers = async cozyClient => {
+  try {
+    const { data: ciphers } = await cozyClient.query(
+      cozyClient.find(CIPHERS_DOCTYPE)
+    )
+
+    return ciphers.length > 0
+  } catch (err) {
+    console.error('Error while fetching ciphers:')
+    console.error(err)
+
+    return false
+  }
+}
+
 const VaultUnlocker = ({
   children,
   onDismiss,
@@ -28,26 +43,16 @@ const VaultUnlocker = ({
 
   useEffect(() => {
     const checkCiphers = async () => {
-      try {
-        const { data } = await cozyClient.query(cozyClient.find(CIPHERS_DOCTYPE))
+      const hasCiphers = await checkHasCiphers(cozyClient)
+      setHasCiphers(hasCiphers)
+      setIsCheckingCiphers(false)
 
-        const hasCiphers = data.length > 0
-
-        setHasCiphers(hasCiphers)
-
-        // If there is no cipher in the vault, it means the user never used it,
-        // so we don't force them to unlock it for nothing
-        if (!hasCiphers && onUnlock) {
-          onUnlock()
-        }
-      } catch (err) {
-        /* eslint-disable no-console */
-        console.error(`Error while fetching ${CIPHERS_DOCTYPE}:`)
-        console.error(err)
-        /* eslint-enable no-console */
-      } finally {
-        setIsCheckingCiphers(false)
+      // If there is no cipher in the vault, it means the user never used it,
+      // so we don't force them to unlock it for nothing
+      if (!hasCiphers && onUnlock) {
+        onUnlock()
       }
+
     }
 
     checkCiphers()

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -29,9 +29,7 @@ const VaultUnlocker = ({
   useEffect(() => {
     const checkCiphers = async () => {
       try {
-        const { data } = await cozyClient.query(
-          cozyClient.find(CIPHERS_DOCTYPE).where({ shared_with_cozy: true })
-        )
+        const { data } = await cozyClient.query(cozyClient.find(CIPHERS_DOCTYPE))
 
         const hasCiphers = data.length > 0
 

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -14,6 +14,10 @@ const locales = {
 
 const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
 
+const isForbiddenError = rawError => {
+  return rawError.message.match(/code=403/)
+}
+
 const checkHasCiphers = async cozyClient => {
   try {
     const { data: ciphers } = await cozyClient.query(
@@ -23,7 +27,13 @@ const checkHasCiphers = async cozyClient => {
     return ciphers.length > 0
   } catch (err) {
     console.error('Error while fetching ciphers:')
-    console.error(err)
+    if (isForbiddenError(err)) {
+      console.error(
+        `Your app must have the GET permission on the ${CIPHERS_DOCTYPE} doctype.`
+      )
+    } else {
+      console.error(err)
+    }
 
     return false
   }

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -6,67 +6,11 @@ import localesEn from '../locales/en.json'
 import localesFr from '../locales/fr.json'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { withClient } from 'cozy-client'
+import { checkHasCiphers, checkHasCozyOrg } from '../utils'
 
 const locales = {
   en: localesEn,
   fr: localesFr
-}
-
-const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
-const SETTINGS_DOCTYPE = 'io.cozy.settings'
-
-const isForbiddenError = rawError => {
-  return rawError.message.match(/code=403/)
-}
-
-const checkHasCiphers = async cozyClient => {
-  try {
-    const { data: ciphers } = await cozyClient.query(
-      cozyClient.find(CIPHERS_DOCTYPE)
-    )
-
-    return ciphers.length > 0
-  } catch (err) {
-    /* eslint-disable no-console */
-    console.error('Error while fetching ciphers:')
-    if (isForbiddenError(err)) {
-      console.error(
-        `Your app must have the GET permission on the ${CIPHERS_DOCTYPE} doctype.`
-      )
-    } else {
-      console.error(err)
-    }
-    /* eslint-enable no-console */
-
-    return false
-  }
-}
-
-const checkHasCozyOrg = async cozyClient => {
-  try {
-    const { rows: docs } = await cozyClient
-      .getStackClient()
-      .fetchJSON('GET', `/data/${SETTINGS_DOCTYPE}/_normal_docs`)
-
-    const [bitwardenSettings] = docs.filter(
-      doc => doc._id === 'io.cozy.settings.bitwarden'
-    )
-
-    return bitwardenSettings && bitwardenSettings.organization_id
-  } catch (err) {
-    /* eslint-disable no-console */
-    console.error('Error while fetching bitwarden settings:')
-    if (isForbiddenError(err)) {
-      console.error(
-        `Your app must have the GET permission on the ${SETTINGS_DOCTYPE} doctype.`
-      )
-    } else {
-      console.error(err)
-    }
-    /* eslint-enable no-console */
-
-    return false
-  }
 }
 
 const VaultUnlocker = ({

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,56 @@
+const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
+const SETTINGS_DOCTYPE = 'io.cozy.settings'
+
+const isForbiddenError = rawError => {
+  return rawError.message.match(/code=403/)
+}
+
+export const checkHasCiphers = async cozyClient => {
+  try {
+    const { data: ciphers } = await cozyClient.query(
+      cozyClient.find(CIPHERS_DOCTYPE)
+    )
+
+    return ciphers.length > 0
+  } catch (err) {
+    /* eslint-disable no-console */
+    console.error('Error while fetching ciphers:')
+    if (isForbiddenError(err)) {
+      console.error(
+        `Your app must have the GET permission on the ${CIPHERS_DOCTYPE} doctype.`
+      )
+    } else {
+      console.error(err)
+    }
+    /* eslint-enable no-console */
+
+    return false
+  }
+}
+
+export const checkHasCozyOrg = async cozyClient => {
+  try {
+    const { rows: docs } = await cozyClient
+      .getStackClient()
+      .fetchJSON('GET', `/data/${SETTINGS_DOCTYPE}/_normal_docs`)
+
+    const [bitwardenSettings] = docs.filter(
+      doc => doc._id === 'io.cozy.settings.bitwarden'
+    )
+
+    return bitwardenSettings && bitwardenSettings.organization_id
+  } catch (err) {
+    /* eslint-disable no-console */
+    console.error('Error while fetching bitwarden settings:')
+    if (isForbiddenError(err)) {
+      console.error(
+        `Your app must have the GET permission on the ${SETTINGS_DOCTYPE} doctype.`
+      )
+    } else {
+      console.error(err)
+    }
+    /* eslint-enable no-console */
+
+    return false
+  }
+}


### PR DESCRIPTION
Previously we auto unlocked the vault by checking if we can find some ciphers shared with the cozy org directly in couch databases.

This doesn't work in all cases as it's possible that:

* The vault contains ciphers not shared with the cozy org
* The vault has been initialized, but is empty

So now we also check for the cozy org existence. The condition to ask for the user to unlock his vault is now the existence of some ciphers or the existence of the cozy org.