### PR TITLE
feat(VaultUnlocker): Update should unlock condition

### DIFF
--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -6,7 +6,7 @@ import localesEn from '../locales/en.json'
 import localesFr from '../locales/fr.json'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { withClient } from 'cozy-client'
-import { checkHasCiphers, checkHasCozyOrg } from '../utils'
+import { checkHasCiphers } from '../utils'
 
 const locales = {
   en: localesEn,
@@ -28,8 +28,7 @@ const VaultUnlocker = ({
   useEffect(() => {
     const checkShouldUnlock = async () => {
       const hasCiphers = await checkHasCiphers(cozyClient)
-      const hasCozyOrg = await checkHasCozyOrg(cozyClient)
-      const shouldUnlock = hasCiphers || hasCozyOrg
+      const shouldUnlock = hasCiphers
 
       setShouldUnlock(shouldUnlock)
       setIsChecking(false)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const CIPHERS_DOCTYPE = 'com.bitwarden.ciphers'
-const SETTINGS_DOCTYPE = 'io.cozy.settings'
 
 const isForbiddenError = rawError => {
   return rawError.message.match(/code=403/)
@@ -18,33 +17,6 @@ export const checkHasCiphers = async cozyClient => {
     if (isForbiddenError(err)) {
       console.error(
         `Your app must have the GET permission on the ${CIPHERS_DOCTYPE} doctype.`
-      )
-    } else {
-      console.error(err)
-    }
-    /* eslint-enable no-console */
-
-    return false
-  }
-}
-
-export const checkHasCozyOrg = async cozyClient => {
-  try {
-    const { rows: docs } = await cozyClient
-      .getStackClient()
-      .fetchJSON('GET', `/data/${SETTINGS_DOCTYPE}/_normal_docs`)
-
-    const [bitwardenSettings] = docs.filter(
-      doc => doc._id === 'io.cozy.settings.bitwarden'
-    )
-
-    return bitwardenSettings && bitwardenSettings.organization_id
-  } catch (err) {
-    /* eslint-disable no-console */
-    console.error('Error while fetching bitwarden settings:')
-    if (isForbiddenError(err)) {
-      console.error(
-        `Your app must have the GET permission on the ${SETTINGS_DOCTYPE} doctype.`
       )
     } else {
       console.error(err)


### PR DESCRIPTION
It turns out that the cozy org is created when the instance is created.
It means it's always there, so checking its existence is useless. We
decided to only check the presence of ciphers for now.