### PR TITLE
Don't lock cozy-ui version and update it

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "big-integer": "^1.6.44",
     "classnames": "^2.2.6",
     "cozy-device-helper": "^1.7.5",
-    "cozy-ui": "^28.7.0",
+    "cozy-ui": "^29.3.1",
     "lodash": "^4.17.15",
     "lunr": "^2.3.6",
     "microee": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "big-integer": "^1.6.44",
     "classnames": "^2.2.6",
     "cozy-device-helper": "^1.7.5",
-    "cozy-ui": "28.7.0",
+    "cozy-ui": "^28.7.0",
     "lodash": "^4.17.15",
     "lunr": "^2.3.6",
     "microee": "^0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,10 +2774,10 @@ cozy-stack-client@^8.8.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^28.7.0:
-  version "28.13.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.13.0.tgz#85854c3f7b8a39873e301c476e09459cb2b667a9"
-  integrity sha512-CrXod4wNYAn7CMT/OyhgGiX0r0eEO9xdXaELimLzI1R4vJjwJaQHy2jETiBzmXv+sQ5OdnTJ+rvWQVfGpaR6Xw==
+cozy-ui@^29.3.1:
+  version "29.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-29.3.1.tgz#b0d3760e966f28dbcc6b04d3adfb6b95914b8292"
+  integrity sha512-2Q9VGcgvvYxmN++Tt2M0WdDW4GhtBGfS9OO3KaOMviyfNVU8K27x9zdRCRLWTPKGdLPafX5LvuCAVdPalVnbyQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,10 +2774,10 @@ cozy-stack-client@^8.8.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@28.7.0:
-  version "28.7.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.7.0.tgz#0e3e3ab3bb7675cdbd80f6938c4d81eb1e5b6345"
-  integrity sha512-iKfatJLKlN3QMNqzIBYCvZ43ZYxCjA2NBOQBqmWqKOvhwV5W5C8V1tbwEVqo/Drk51SERl6T6wGaNN6huP+//g==
+cozy-ui@^28.7.0:
+  version "28.13.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.13.0.tgz#85854c3f7b8a39873e301c476e09459cb2b667a9"
+  integrity sha512-CrXod4wNYAn7CMT/OyhgGiX0r0eEO9xdXaELimLzI1R4vJjwJaQHy2jETiBzmXv+sQ5OdnTJ+rvWQVfGpaR6Xw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Locking the cozy-ui version will most likely result in multiple cozy-uis embedded in an app build. We should not lock the version in a library.

Also update cozy-ui.