### PR TITLE
fix: Don't stub tldjs dep

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -19,10 +19,6 @@ module.exports = {
                 location: '../../../stubs/null.js'
               },
               {
-                pattern: '^tldjs$',
-                location: '../../../stubs/null.js'
-              },
-              {
                 pattern: '^sweetalert',
                 location: './stubs/null.js'
               },


### PR DESCRIPTION
Stubbing tldjs didn't throw an error while I was working on #43,
replacing tldjs by a stub file didn't break tests nor harvest. Actually,
it's required but bitwarden's jslib has defensive code to handle its
absence (see
https://github.com/bitwarden/jslib/blob/master/src/misc/utils.ts#L198).
The problem is that the behavior is not the same with and without it.
And it prevented us from matching `www.tartanpion.com` with
`tartanpion.com` in harvest. Thus not proposing a cipher to the user
because the konnector's vendor_link is `tartanpion.com`, but the cipher
has been created with `www.tartanpion.com` URI.