### PR TITLE
fix(UnlockForm): The onDismiss prop is not required on UnlockForm

### DIFF
--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -171,7 +171,7 @@ class UnlockForm extends React.Component {
 UnlockForm.propTypes = {
   vaultClient: PropTypes.object.isRequired,
   t: PropTypes.func.isRequired,
-  onDismiss: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func,
   closable: PropTypes.bool,
   client: PropTypes.object.isRequired,
   onUnlock: PropTypes.func


### PR DESCRIPTION
This prop enables us to react to the dismiss of the UnlockForm. But we don't always want to do something when the UnlockForm is dismissed. So it's not required.