### PR TITLE
feat: Add node version without React components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "cozy-keys-lib",
   "version": "0.0.0-development",
   "description": "Interactions between cozy-keys and a bitwarden server",
-  "main": "transpiled/index.js",
+  "browser": "transpiled/index.js",
+  "main": "transpiled/index.node.js",
   "scripts": {
     "setup:submodule": "git submodule init && git submodule update",
     "setup": "yarn run setup:submodule",

--- a/src/index.node.js
+++ b/src/index.node.js
@@ -1,0 +1,4 @@
+export { default as WebVaultClient } from './WebVaultClient'
+export * as CozyUtils from './CozyUtils'
+export { default as CipherType } from './CipherType'
+export { default as UriMatchType } from './UriMatchType'


### PR DESCRIPTION
This is useful when making CLI for libraries using cozy-keys-lib
like harvest