### PR TITLE
perf(import): Import ciphers in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "lunr": "^2.3.6",
     "microee": "^0.0.6",
     "node-forge": "^0.9.0",
+    "p-limit": "^2.2.2",
     "papaparse": "^5.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.3",

--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -772,68 +772,73 @@ class WebVaultClient {
         }
       }
 
-      for (let i = 0; i < parseResult.ciphers.length; ++i) {
-        const importingCipher = parseResult.ciphers[i]
-        let cipherToSave
-
-        let encryptedExistingCipher
-
-        // Since we search existing cipher by username, password and URI; and a
-        // cipher being imported can have multiple URIs, we have to look for an
-        // existing cipher for each URI. The getByIdOrSearch API may be better
-        // and accept an array of strings
-        for (const uri of importingCipher.login.uris) {
-          const search = {
-            username: importingCipher.login.username,
-            uri: uri._uri,
-            type: CipherType.Login
-          }
-
-          const sort = [
-            view => view.login.password === importingCipher.login.password,
-            'revisionDate'
-          ]
-
-          encryptedExistingCipher = await this.getByIdOrSearch(
-            null,
-            search,
-            sort
-          )
-
-          if (encryptedExistingCipher) {
-            break
-          }
-        }
-
-        if (encryptedExistingCipher) {
-          const decryptedExistingCipher = await this.decrypt(
-            encryptedExistingCipher
-          )
-
-          for (const uri of importingCipher.login.uris) {
-            const hasUri = decryptedExistingCipher.login.uris.find(
-              existingUri =>
-                existingUri.match === uri.match && existingUri.uri === uri.uri
-            )
-
-            if (!hasUri) {
-              decryptedExistingCipher.login.uris.push(uri)
-            }
-          }
-
-          cipherToSave = await this.createNewCipher(
-            decryptedExistingCipher,
-            encryptedExistingCipher
-          )
-        } else {
-          cipherToSave = await this.createNewCipher(importingCipher)
-        }
-
-        await this.saveCipher(cipherToSave)
-      }
+      await Promise.all(
+        parseResult.ciphers.map(cipher => this.importCipher(cipher))
+      )
     } else {
       throw new Error('IMPORT_FORMAT_ERROR')
     }
+  }
+
+  /**
+   * Imports a single cipher in the vault
+   *
+   * @param {CipherView} cipher - the cipher to import
+   */
+  async importCipher(cipher) {
+    cipher.login.uris = cipher.login.uris || []
+
+    let cipherToSave
+    let encryptedExistingCipher
+
+    // Since we search existing cipher by username, password and URI; and a
+    // cipher being imported can have multiple URIs, we have to look for an
+    // existing cipher for each URI. The getByIdOrSearch API may be better
+    // and accept an array of strings
+    for (const uri of cipher.login.uris) {
+      const search = {
+        username: cipher.login.username,
+        uri: uri._uri,
+        type: CipherType.Login
+      }
+
+      const sort = [
+        view => view.login.password === cipher.login.password,
+        'revisionDate'
+      ]
+
+      encryptedExistingCipher = await this.getByIdOrSearch(null, search, sort)
+
+      if (encryptedExistingCipher) {
+        break
+      }
+    }
+
+    if (encryptedExistingCipher) {
+      const decryptedExistingCipher = await this.decrypt(
+        encryptedExistingCipher
+      )
+
+      for (const uri of cipher.login.uris) {
+        const hasUri = decryptedExistingCipher.login.uris.find(
+          existingUri =>
+            existingUri.match === uri.match && existingUri.uri === uri.uri
+        )
+
+        if (!hasUri) {
+          decryptedExistingCipher.login.uris.push(uri)
+        }
+      }
+
+      cipherToSave = await this.createNewCipher(
+        decryptedExistingCipher,
+        encryptedExistingCipher
+      )
+    } else {
+      cipherToSave = await this.createNewCipher(cipher)
+    }
+
+    await this.saveCipher(cipherToSave)
   }
 
   getImportOptions() {

--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -38,6 +38,8 @@ import MemoryStorageService from './MemoryStorageService'
 
 import * as CozyUtils from './CozyUtils'
 
+import pLimit from 'p-limit'
+
 Utils.init()
 
 /**
@@ -772,9 +774,11 @@ class WebVaultClient {
         }
       }
 
-      await Promise.all(
-        parseResult.ciphers.map(cipher => this.importCipher(cipher))
+      const limit = pLimit(50)
+      const promises = parseResult.ciphers.map(cipher => async () =>
+        this.importCipher(cipher)
       )
+      await Promise.all(promises.map(limit))
     } else {
       throw new Error('IMPORT_FORMAT_ERROR')
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6974,6 +6974,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"


### PR DESCRIPTION
Importing ciphers in parallel makes it 10x faster on a batch of 100
ciphers.

Previously ciphers were imported sequentially, which was not so effective because lot of steps in the import process are asynchronous, so we didn't take advantage of this.

Related to https://github.com/cozy/cozy-keys-lib/pull/81#discussion_r385008465