### PR TITLE
fix: Move deps to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,11 +49,14 @@
     "babel-plugin-rewire": "1.2.0",
     "babel-preset-cozy-app": "^1.6.0",
     "cozy-client": "^8.8.0",
+    "cozy-ui": "^29.9.1",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "3.4.0",
     "eslint-config-cozy-app": "^1.2.2",
     "jest": "24.9.0",
+    "react": "^16.8.3",
+    "react-dom": "^16.9.0",
     "semantic-release": "^15.13.24"
   },
   "files": [
@@ -67,7 +70,6 @@
     "big-integer": "^1.6.44",
     "classnames": "^2.2.6",
     "cozy-device-helper": "^1.7.5",
-    "cozy-ui": "^29.9.1",
     "lodash": "^4.17.15",
     "lunr": "^2.3.6",
     "microee": "^0.0.6",
@@ -75,13 +77,14 @@
     "p-limit": "^2.2.2",
     "papaparse": "^5.1.1",
     "prop-types": "^15.7.2",
-    "react": "^16.8.3",
-    "react-dom": "^16.9.0",
     "sweetalert": "^2.1.2",
     "tldjs": "^2.3.1",
     "zxcvbn": "^4.4.2"
   },
   "peerDependencies": {
-    "cozy-client": "^8.8.0"
+    "cozy-ui": "^29.9.1",
+    "cozy-client": "^8.8.0",
+    "react": "^16.8.3",
+    "react-dom": "^16.9.0"
   }
 }


### PR DESCRIPTION
Using a normal dep for react would introduce in apps two versions of
React where we only want 1. The symptom in apps would be error when
using hooks since we were importing the hook function from 1 version
of React and using it in another React instance