### PR TITLE
refactor: Separate cipher matching from cipher saving

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -676,6 +676,18 @@ class WebVaultClient {
   }
 
   /**
+   * Saves a new or modified (encrypted) ciphers to the server
+   * @param {Cipher} - cipher to save
+   */
+  async saveCiphers(ciphers) {
+    const limit = pLimit(50)
+    const promiseMakers = ciphers.map(cipher => async () => {
+      return this.saveCipher(cipher)
+    })
+    await Promise.all(promiseMakers.map(limit))
+  }
+
+  /**
    * Delete a cipher by its id
    * @param {string} id - uuid of the cipher
    */
@@ -798,11 +810,7 @@ class WebVaultClient {
         .map(cipher => this.prepareCipherToImport(cipher))
     )
 
-    const limit = pLimit(50)
-    const promiseMakers = ciphersToSave.map(cipher => async () => {
-      return this.saveCipher(cipher)
-    })
-    await Promise.all(promiseMakers.map(limit))
+    await this.saveCiphers(ciphersToSave)
   }
 
   async searchExistingCipher(cipher) {

--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -752,6 +752,24 @@ class WebVaultClient {
   }
 
   /**
+   * Crude way to check if an import seems to have been done correctly
+   *
+   * Copy/pasted from ImportService::import
+   */
+  assertImportedCiphersSeemOK(importedCiphers) {
+    const halfway = Math.floor(importedCiphers.length / 2)
+    const last = importedCiphers.length - 1
+
+    if (
+      this.importService.badData(importedCiphers[0]) &&
+      this.importService.badData(importedCiphers[halfway]) &&
+      this.importService.badData(importedCiphers[last])
+    ) {
+      throw new Error('IMPORT_BAD_FILE_CONTENT')
+    }
+  }
+
+  /**
    * Import ciphers contained in a file in a given format
    *
    * @param {string} fileContent - the raw content of the file being imported
@@ -767,18 +785,8 @@ class WebVaultClient {
     const parseResult = await importer.parse(fileContent)
 
     if (parseResult.success) {
-      // Error case copy/pasted from ImportService::import
       if (parseResult.ciphers.length > 0) {
-        const halfway = Math.floor(parseResult.ciphers.length / 2)
-        const last = parseResult.ciphers.length - 1
-
-        if (
-          this.importService.badData(parseResult.ciphers[0]) &&
-          this.importService.badData(parseResult.ciphers[halfway]) &&
-          this.importService.badData(parseResult.ciphers[last])
-        ) {
-          throw new Error('IMPORT_BAD_FILE_CONTENT')
-        }
+        this.assertImportedCiphersSeemOK(parseResult.ciphers)
       }
 
       const ciphersToSave = await Promise.all(

--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -784,25 +784,25 @@ class WebVaultClient {
 
     const parseResult = await importer.parse(fileContent)
 
-    if (parseResult.success) {
-      if (parseResult.ciphers.length > 0) {
-        this.assertImportedCiphersSeemOK(parseResult.ciphers)
-      }
-
-      const ciphersToSave = await Promise.all(
-        parseResult.ciphers
-          .filter(cipher => isSupportedCipher(cipher))
-          .map(cipher => this.prepareCipherToImport(cipher))
-      )
-
-      const limit = pLimit(50)
-      const promiseMakers = ciphersToSave.map(cipher => async () => {
-        return this.saveCipher(cipher)
-      })
-      await Promise.all(promiseMakers.map(limit))
-    } else {
+    if (!parseResult.success) {
       throw new Error('IMPORT_FORMAT_ERROR')
     }
+
+    if (parseResult.ciphers.length > 0) {
+      this.assertImportedCiphersSeemOK(parseResult.ciphers)
+    }
+
+    const ciphersToSave = await Promise.all(
+      parseResult.ciphers
+        .filter(cipher => isSupportedCipher(cipher))
+        .map(cipher => this.prepareCipherToImport(cipher))
+    )
+
+    const limit = pLimit(50)
+    const promiseMakers = ciphersToSave.map(cipher => async () => {
+      return this.saveCipher(cipher)
+    })
+    await Promise.all(promiseMakers.map(limit))
   }
 
   async searchExistingCipher(cipher) {


### PR DESCRIPTION
Before, the matching of a cipher was done just before saving.
For batch import, we need to be able to have a matching phase for all
ciphers and then a saving phase where we send all ciphers. Here we
refactor the code to make the matching phase more apparent (mapping all
ciphers into prepareCipherToImport) and then we save them all. In a
future commit, the map to saveCipher will be replaced by a batch save.