### PR TITLE
fix: Render null if no children

### DIFF
--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -57,7 +57,7 @@ const VaultUnlocker = ({
   return locked && shouldUnlock ? (
     <UnlockForm onDismiss={onDismiss} closable={closable} onUnlock={onUnlock} />
   ) : (
-    children
+    children || null
   )
 }
 


### PR DESCRIPTION
When using `VaultUnlocker` with no children, an error `Error: VaultUnlocker(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.` is raised