### PR TITLE
feat: Move VaultUnlock components from harvest

### DIFF
--- a/src/components/VaultUnlockPlaceholder.jsx
+++ b/src/components/VaultUnlockPlaceholder.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { useVaultUnlockContext } from './vaultUnlockContext'
+import VaultUnlocker from './VaultUnlocker'
+
+export const VaultUnlockPlaceholder = ({
+  unlockFormProps: unlockFormPropsProp
+}) => {
+  const { showingUnlockForm, unlockFormProps } = useVaultUnlockContext()
+  if (!showingUnlockForm) {
+    return null
+  }
+  return <VaultUnlocker {...unlockFormProps} {...unlockFormPropsProp} />
+}
+
+export default VaultUnlockPlaceholder

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { VaultContext } from './VaultContext'
 import UnlockForm from './UnlockForm'
 import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
@@ -65,6 +66,12 @@ const VaultUnlocker = ({ children, onDismiss, closable, onUnlock }) => {
   ) : (
     children || null
   )
+}
+
+VaultUnlocker.propTypes = {
+  onDismiss: PropTypes.func.isRequired,
+  closable: PropTypes.bool,
+  onUnlock: PropTypes.func.isRequired
 }
 
 export default withLocales(locales)(VaultUnlocker)

--- a/src/components/defaults.js
+++ b/src/components/defaults.js
@@ -1,0 +1,7 @@
+import { checkHasInstalledExtension } from '../CozyUtils'
+
+export const checkShouldUnlock = async (vaultClient, client) => {
+  return (
+    (await checkHasInstalledExtension(client)) && (await vaultClient.isLocked())
+  )
+}

--- a/src/components/vaultUnlockContext.jsx
+++ b/src/components/vaultUnlockContext.jsx
@@ -1,0 +1,71 @@
+import React, { useMemo, useState, useContext } from 'react'
+import { useClient } from 'cozy-client'
+import { useVaultClient } from './VaultContext'
+import * as CozyUtils from '../CozyUtils'
+
+const vaultUnlockContext = React.createContext()
+export const useVaultUnlockContext = () => {
+  return useContext(vaultUnlockContext)
+}
+
+export const VaultUnlockProvider = ({ children }) => {
+  const client = useClient()
+  const vaultClient = useVaultClient()
+  const [showingUnlockForm, setShowingUnlockForm] = useState(false)
+  const [unlockFormProps, setUnlockFormProps] = useState(null)
+
+  const value = useMemo(() => {
+    const showUnlockForm = async unlockFormProps => {
+      if (!unlockFormProps || !unlockFormProps.onUnlock) {
+        throw new Error(
+          'onUnlock must be passed in showUnlockForm options. showUnlockForm({ onUnlock: () => alert("Vault has been unlocked") })'
+        )
+      }
+      const onUnlock = () => {
+        setShowingUnlockForm(false)
+        unlockFormProps.onUnlock && unlockFormProps.onUnlock()
+      }
+      const onDismiss = () => {
+        setShowingUnlockForm(false)
+        unlockFormProps.onDismiss && unlockFormProps.onDismiss()
+      }
+
+      const shouldUnlock =
+        (await CozyUtils.checkHasInstalledExtension(client)) &&
+        (await vaultClient.isLocked())
+      if (shouldUnlock) {
+        setUnlockFormProps({
+          ...unlockFormProps,
+          onUnlock,
+          onDismiss
+        })
+        setShowingUnlockForm(true)
+      } else {
+        onUnlock()
+      }
+    }
+
+    return {
+      showingUnlockForm,
+      showUnlockForm,
+      unlockFormProps,
+      vaultClient
+    }
+  }, [showingUnlockForm, unlockFormProps, vaultClient, client])
+
+  return (
+    <vaultUnlockContext.Provider value={value}>
+      {children}
+    </vaultUnlockContext.Provider>
+  )
+}
+
+export const withVaultUnlockContext = Component => {
+  const Wrapper = props => {
+    const vaultUnlockContextValue = useVaultUnlockContext()
+    return <Component {...props} {...vaultUnlockContextValue} />
+  }
+  Wrapper.displayName = `withVaultUnlockContext(${Component.displayName ||
+    Component.name})`
+  return Wrapper
+}

--- a/src/components/vaultUnlockContext.jsx
+++ b/src/components/vaultUnlockContext.jsx
@@ -8,6 +8,38 @@ export const useVaultUnlockContext = () => {
   return useContext(vaultUnlockContext)
 }
 
+/**
+ * Provides a way to unlock the vault from the context
+ *
+ * The context stores whether the vault unlocking form is
+ * shown. This is used by the VaultPlaceholder to decide
+ * whether it needs to show the unlock form.
+ *
+ * If the vault has not been setup or if it is already unlocked,
+ * the showUnlockForm function in the context value, will
+ * call the onUnlock function immediately.
+ *
+ * @example
+ * ```
+ * import { VaultUnlockPlaceholder, useVaultUnlockContext } from 'cozy-keys-lib'
+ *
+ * const Component = ({ onUnlock }) => {
+ *   const { showUnlockForm } = useVaultUnlockContext()
+ *   return (
+ *     <div>
+ *       <button onClick={() => showUnlockForm({ onUnlock })} role="button">
+ *         show unlock form
+ *       </button>
+ *     </div>
+ *   )
+ * }
+ *
+ * <VaultProvider instance='http://cozy.tools:8080'>
+ *   <Component onUnlock={() => alert('vault has been unlocked')} />
+ *   <VaultUnlockPlaceholder />
+ * </VaultProvider>
+ * ```
+ */
 export const VaultUnlockProvider = ({ children }) => {
   const client = useClient()
   const vaultClient = useVaultClient()

--- a/src/components/vaultUnlockContext.spec.jsx
+++ b/src/components/vaultUnlockContext.spec.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render, act, fireEvent } from '@testing-library/react'
+import {
+  VaultUnlockProvider,
+  useVaultUnlockContext
+} from './vaultUnlockContext'
+import { checkHasInstalledExtension } from '../CozyUtils'
+import { useVaultClient } from './VaultContext'
+
+jest.mock('./VaultContext', () => ({
+  useVaultClient: jest.fn()
+}))
+
+jest.mock('../CozyUtils', () => ({
+  checkHasInstalledExtension: jest.fn()
+}))
+
+describe('vault unlock context', () => {
+  const Component = ({ onUnlock }) => {
+    const { showingUnlockForm, showUnlockForm } = useVaultUnlockContext()
+    return (
+      <div>
+        {'showingUnlockForm: ' + showingUnlockForm.toString()}
+        <button onClick={() => showUnlockForm({ onUnlock })} role="button">
+          show unlock form
+        </button>
+      </div>
+    )
+  }
+
+  const setup = async () => {
+    const onUnlock = jest.fn()
+    const root = render(
+      <VaultUnlockProvider>
+        <Component onUnlock={onUnlock} />
+      </VaultUnlockProvider>
+    )
+
+    await act(async () => {
+      toggleUnlockForm(root)
+    })
+
+    return { root, onUnlock }
+  }
+
+  const toggleUnlockForm = root => {
+    fireEvent.click(root.getByText('show unlock form'))
+  }
+
+  it('should show unlock form if vault should be unlocked', async () => {
+    useVaultClient.mockReturnValue({
+      isLocked: jest.fn().mockResolvedValue(true)
+    })
+    checkHasInstalledExtension.mockResolvedValue(true)
+    const { root, onUnlock } = await setup()
+    root.getByText('showingUnlockForm: true')
+    expect(onUnlock).not.toHaveBeenCalled()
+  })
+
+  it('should not show unlock form and call onUnlock if extension is not installed', async () => {
+    useVaultClient.mockReturnValue({
+      isLocked: jest.fn().mockResolvedValue(true)
+    })
+    checkHasInstalledExtension.mockResolvedValue(false)
+    const { root, onUnlock } = await setup()
+    expect(root.getByText('showingUnlockForm: false')).toBeTruthy()
+    expect(onUnlock).toHaveBeenCalled()
+  })
+
+  it('should not show unlock form and call onUnlock if vault is unlocked', async () => {
+    useVaultClient.mockReturnValue({
+      isLocked: jest.fn().mockResolvedValue(false)
+    })
+    checkHasInstalledExtension.mockResolvedValue(true)
+    const { root, onUnlock } = await setup()
+    expect(root.getByText('showingUnlockForm: false')).toBeTruthy()
+    expect(onUnlock).toHaveBeenCalled()
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,9 @@ export {
 } from './components/VaultContext'
 
 export VaultUnlocker from './components/VaultUnlocker'
+export VaultUnlockPlaceholder from './components/VaultUnlockPlaceholder'
+export {
+  useVaultUnlockContext,
+  VaultUnlockProvider,
+  withVaultUnlockContext
+} from './components/vaultUnlockContext'


### PR DESCRIPTION
Moved code that was originally in Harvest so that all code managing the 
vault is in cozy-keys-lib Additionally, an additional check in
showUnlockForm has been added to check if the extension has been installed.
This way, the user of the lib, does not need to do the check. If the
extension is not installed or if the vault already is unlocked, onUnlock is
called immediately.