### PR TITLE
fix: Remove warnings for users of the lib

### DIFF
--- a/src/stubs/null.js
+++ b/src/stubs/null.js
@@ -1,1 +1,3 @@
+export const EEFLongWordList = []
+
 export default null


### PR DESCRIPTION
stubs/null is used to remove large unused files from what's built
inside cozy-keys-lib. Unfortunately, since it did not export
EEFLongWordList, we would have warnings inside webpack telling us
that EEFLongWordList was not exported from stubs/null. Since we do
not use currently this long word list, and we do not want to have this
warning polluting our consoles, let's export an empty list here.

No more warnings for the users of the lib !