### PR TITLE
feat: Specific vault unlocker display for oidc

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-rewire": "1.2.0",
     "babel-preset-cozy-app": "^1.6.0",
     "cozy-client": "^16.10.2",
+    "cozy-flags": "2.6.0",
     "cozy-ui": "^42.3.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
@@ -85,6 +86,7 @@
   "peerDependencies": {
     "cozy-client": "^16.10.2",
     "cozy-ui": "^42.3.0",
+    "cozy-flags": "^2.6.0",
     "react": "^16.8.3",
     "react-dom": "^16.9.0"
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,9 +1,11 @@
 {
   "unlock": {
     "title": "Login",
+    "title-oidc": "Cozy Pass",
     "subtitle": "For security, please confirm your identity",
     "error": "Incorrect password",
     "label": "Cozy password",
+    "label-oidc": "Cozy Pass password",
     "show": "show",
     "hide": "hide",
     "abort": "Leave",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,9 +1,11 @@
 {
   "unlock": {
     "title": "Authentification",
+    "title-oidc": "Cozy Pass",
     "subtitle": "Par sécurité, merci de confirmer votre identité",
     "error": "Mot de passe incorrect, essayer à nouveau",
     "label": "Mot de passe Cozy",
+    "label-oidc": "Mot de passe Cozy Pass",
     "show": "afficher",
     "hide": "masquer",
     "abort": "Quitter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,6 +3406,13 @@ cozy-device-helper@^1.7.5:
   dependencies:
     lodash "4.17.15"
 
+cozy-flags@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-2.6.0.tgz#c336b154ef94723c151f26ef2782a4d0650b4593"
+  integrity sha512-8Jsdct51bZaUsp5aPbfb/4ZLmktWk/gWMM7uxQPcTpatBHqkFgCRdC7Shn7cYoGDoZ+SUPLk7dVsb5AKydb6EA==
+  dependencies:
+    microee "^0.0.6"
+
 cozy-interapp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"


### PR DESCRIPTION
For cozies that authenticate with an external provider, we want to
make sure that the unlock vault modal is precise enough so that
the user enters the vault password and not its Cozy password.

We change the icon and the text to show that the password that is to be entered is the vault one.