### PR TITLE
feat: add optional dependency injection to VaultContext

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -65,6 +65,24 @@ const isSupportedCipher = cipher => cipher.login
  * const all = vault.getAllDecrypted({type: CipherType.Login})
  * ```
  */
+
+/**
+ * @typedef {object} VaultData
+ * @property {ApiService} apiService
+ * @property {EnvironmentService} environmentService
+ * @property {AuthService} authService
+ * @property {SyncService} syncService
+ * @property {CryptoService} cryptoService
+ * @property {CipherService} cipherService
+ * @property {UserService} userService
+ * @property {CollectionService} collectionService
+ * @property {PasswordGenerationService} passwordGenerationService
+ * @property {ContainerService} containerService
+ * @property {VaultTimeoutService} vaultTimeoutService
+ * @property {ImportService} importService
+ * @property {Utils} utils
+ */
+
 class WebVaultClient {
   /**
    * @constructor
@@ -76,8 +94,13 @@ class WebVaultClient {
    * @param {string} options.urls.identity - URL of the identity server
    * @param {string} options.urls.api - URL of the api server
    * @param {string} options.urls.events - URL of the events server
+   * @param {VaultData} vaultData - optional Vault related services that may be injected
    */
-  constructor(instance_or_email, { urls, locale, unsafeStorage } = {}) {
+  constructor(
+    instance_or_email,
+    { urls, locale, unsafeStorage } = {},
+    vaultData = undefined
+  ) {
     this.instance = instance_or_email
     this.email = CozyUtils.getEmail(instance_or_email)
 
@@ -90,144 +113,160 @@ class WebVaultClient {
     }
 
     this.locale = locale || 'en'
-    this.init({ unsafeStorage })
+    this.init({ unsafeStorage }, vaultData)
   }
 
   /*
    * @private
    * Initialize the undelying libraries
    */
-  init({ unsafeStorage }) {
-    const messagingService = new NoopMessagingService()
-    const i18nService = new I18nService(this.locale, './locales')
-    const platformUtilsService = this.initPlatformUtilsService(
-      i18nService,
-      messagingService
-    )
-    const cryptoFunctionService = this.initCryptoFunctionService(
-      platformUtilsService
-    )
-    const storageService = this.initStorageService(platformUtilsService)
-    const secureStorageService = this.initSecureStorageService()
-    const cryptoService = new CryptoService(
-      storageService,
-      unsafeStorage ? storageService : secureStorageService,
-      cryptoFunctionService
-    )
-    const tokenService = new TokenService(storageService)
-    const appIdService = new AppIdService(storageService)
-    const apiService = new ApiService(
-      tokenService,
-      platformUtilsService,
-      async expired => messagingService.send('logout', { expired: expired })
-    )
-    const userService = new UserService(tokenService, storageService)
-    const policyService = new PolicyService(userService, storageService)
-    const sendService = new SendService(
-      cryptoService,
-      userService,
-      apiService,
-      storageService,
-      i18nService,
-      cryptoFunctionService
-    )
-    const settingsService = new SettingsService(userService, storageService)
-    let searchService = null
-    const cipherService = new CipherService(
-      cryptoService,
-      userService,
-      settingsService,
-      apiService,
-      storageService,
-      i18nService,
-      () => searchService
-    )
-    const folderService = new FolderService(
-      cryptoService,
-      userService,
-      apiService,
-      storageService,
-      i18nService,
-      cipherService
-    )
-    const collectionService = new CollectionService(
-      cryptoService,
-      userService,
-      storageService,
-      i18nService
-    )
-    searchService = new SearchService(cipherService, platformUtilsService)
-    const vaultTimeoutService = new VaultTimeoutService(
-      cipherService,
-      folderService,
-      collectionService,
-      cryptoService,
-      platformUtilsService,
-      storageService,
-      messagingService,
-      searchService,
-      userService,
-      null
-    )
-    const syncService = new SyncService(
-      userService,
-      apiService,
-      settingsService,
-      folderService,
-      cipherService,
-      cryptoService,
-      collectionService,
-      storageService,
-      messagingService,
-      policyService,
-      sendService,
-      async expired => messagingService.send('logout', { expired })
-    )
-    const passwordGenerationService = new PasswordGenerationService(
-      cryptoService,
-      storageService,
-      policyService
-    )
-    const containerService = new ContainerService(cryptoService)
-    const authService = new AuthService(
-      cryptoService,
-      apiService,
-      userService,
-      tokenService,
-      appIdService,
-      i18nService,
-      platformUtilsService,
-      messagingService
-    )
-    const notificationsService = null
-    const environmentService = new EnvironmentService(
-      apiService,
-      storageService,
-      notificationsService
-    )
-    const importService = new ImportService(
-      cipherService,
-      folderService,
-      apiService,
-      i18nService,
-      collectionService
-    )
-    this.apiService = apiService
-    this.environmentService = environmentService
-    this.authService = authService
-    this.syncService = syncService
-    this.cryptoService = cryptoService
-    this.cipherService = cipherService
-    this.userService = userService
-    this.collectionService = collectionService
-    this.passwordGenerationService = passwordGenerationService
-    this.containerService = containerService
-    this.vaultTimeoutService = vaultTimeoutService
-    this.importService = importService
+  init({ unsafeStorage }, vaultData) {
+    if (vaultData !== undefined) {
+      this.apiService = vaultData.apiService
+      this.environmentService = vaultData.environmentService
+      this.authService = vaultData.authService
+      this.syncService = vaultData.syncService
+      this.cryptoService = vaultData.cryptoService
+      this.cipherService = vaultData.cipherService
+      this.userService = vaultData.userService
+      this.collectionService = vaultData.collectionService
+      this.passwordGenerationService = vaultData.passwordGenerationService
+      this.containerService = vaultData.containerService
+      this.vaultTimeoutService = vaultData.vaultTimeoutService
+      this.importService = vaultData.importService
+      this.Utils = vaultData.utils
+    } else {
+      const messagingService = new NoopMessagingService()
+      const i18nService = new I18nService(this.locale, './locales')
+      const platformUtilsService = this.initPlatformUtilsService(
+        i18nService,
+        messagingService
+      )
+      const cryptoFunctionService = this.initCryptoFunctionService(
+        platformUtilsService
+      )
+      const storageService = this.initStorageService(platformUtilsService)
+      const secureStorageService = this.initSecureStorageService()
+      const cryptoService = new CryptoService(
+        storageService,
+        unsafeStorage ? storageService : secureStorageService,
+        cryptoFunctionService
+      )
+      const tokenService = new TokenService(storageService)
+      const appIdService = new AppIdService(storageService)
+      const apiService = new ApiService(
+        tokenService,
+        platformUtilsService,
+        async expired => messagingService.send('logout', { expired: expired })
+      )
+      const userService = new UserService(tokenService, storageService)
+      const policyService = new PolicyService(userService, storageService)
+      const sendService = new SendService(
+        cryptoService,
+        userService,
+        apiService,
+        storageService,
+        i18nService,
+        cryptoFunctionService
+      )
+      const settingsService = new SettingsService(userService, storageService)
+      let searchService = null
+      const cipherService = new CipherService(
+        cryptoService,
+        userService,
+        settingsService,
+        apiService,
+        storageService,
+        i18nService,
+        () => searchService
+      )
+      const folderService = new FolderService(
+        cryptoService,
+        userService,
+        apiService,
+        storageService,
+        i18nService,
+        cipherService
+      )
+      const collectionService = new CollectionService(
+        cryptoService,
+        userService,
+        storageService,
+        i18nService
+      )
+      searchService = new SearchService(cipherService, platformUtilsService)
+      const vaultTimeoutService = new VaultTimeoutService(
+        cipherService,
+        folderService,
+        collectionService,
+        cryptoService,
+        platformUtilsService,
+        storageService,
+        messagingService,
+        searchService,
+        userService,
+        null
+      )
+      const syncService = new SyncService(
+        userService,
+        apiService,
+        settingsService,
+        folderService,
+        cipherService,
+        cryptoService,
+        collectionService,
+        storageService,
+        messagingService,
+        policyService,
+        sendService,
+        async expired => messagingService.send('logout', { expired })
+      )
+      const passwordGenerationService = new PasswordGenerationService(
+        cryptoService,
+        storageService,
+        policyService
+      )
+      const containerService = new ContainerService(cryptoService)
+      const authService = new AuthService(
+        cryptoService,
+        apiService,
+        userService,
+        tokenService,
+        appIdService,
+        i18nService,
+        platformUtilsService,
+        messagingService
+      )
+      const notificationsService = null
+      const environmentService = new EnvironmentService(
+        apiService,
+        storageService,
+        notificationsService
+      )
+      const importService = new ImportService(
+        cipherService,
+        folderService,
+        apiService,
+        i18nService,
+        collectionService
+      )
+      this.apiService = apiService
+      this.environmentService = environmentService
+      this.authService = authService
+      this.syncService = syncService
+      this.cryptoService = cryptoService
+      this.cipherService = cipherService
+      this.userService = userService
+      this.collectionService = collectionService
+      this.passwordGenerationService = passwordGenerationService
+      this.containerService = containerService
+      this.vaultTimeoutService = vaultTimeoutService
+      this.importService = importService
+      this.Utils = Utils
+    }
     this.attachToGlobal()
     this.initFinished = this.environmentService.setUrls(this.urls)
     this.initFinished.then(() => this.emit('init', this))
-    this.Utils = Utils
   }
 
   initPlatformUtilsService(i18nService, messagingService) {

--- a/src/WebVaultClient.spec.js
+++ b/src/WebVaultClient.spec.js
@@ -37,6 +37,47 @@ describe('WebVaultClient', () => {
         client1.containerService
       )
     })
+
+    it('should allow optional dependency injection', () => {
+      const vaultData = {
+        apiService: {},
+        environmentService: {
+          setUrls: () => Promise.resolve()
+        },
+        authService: {},
+        syncService: {},
+        cryptoService: {},
+        cipherService: {},
+        userService: {},
+        collectionService: {},
+        passwordGenerationService: {},
+        containerService: {},
+        vaultTimeoutService: {},
+        importService: {},
+        utils: {}
+      }
+
+      const client = new WebVaultClient('https://me.cozy.wtf', {}, vaultData)
+
+      expect(Utils.global.bitwardenContainerService).toBe(
+        vaultData.containerService
+      )
+      expect(client.apiService).toBe(vaultData.apiService)
+      expect(client.environmentService).toBe(vaultData.environmentService)
+      expect(client.authService).toBe(vaultData.authService)
+      expect(client.syncService).toBe(vaultData.syncService)
+      expect(client.cryptoService).toBe(vaultData.cryptoService)
+      expect(client.cipherService).toBe(vaultData.cipherService)
+      expect(client.userService).toBe(vaultData.userService)
+      expect(client.collectionService).toBe(vaultData.collectionService)
+      expect(client.passwordGenerationService).toBe(
+        vaultData.passwordGenerationService
+      )
+      expect(client.containerService).toBe(vaultData.containerService)
+      expect(client.vaultTimeoutService).toBe(vaultData.vaultTimeoutService)
+      expect(client.importService).toBe(vaultData.importService)
+      expect(client.Utils).toBe(vaultData.utils)
+    })
   })
 
   describe('weakMatch', () => {

--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -6,7 +6,8 @@ import memoize from 'lodash/memoize'
 const VaultContext = React.createContext()
 
 const getVaultClient = memoize(
-  (instance, unsafeStorage) => new WebVaultClient(instance, { unsafeStorage })
+  (instance, unsafeStorage, vaultData) =>
+    new WebVaultClient(instance, { unsafeStorage }, vaultData)
 )
 
 class VaultProvider extends React.Component {
@@ -49,7 +50,11 @@ class VaultProvider extends React.Component {
   setupClient() {
     const unsafeStorage = this.props.unsafeStorage
 
-    const client = getVaultClient(this.props.instance, unsafeStorage)
+    const client = getVaultClient(
+      this.props.instance,
+      unsafeStorage,
+      this.props.vaultData
+    )
 
     this.setState(
       {


### PR DESCRIPTION
When used from `cozy-pass-web`, `WebVaultClient` may override local `jslib` when it is instantiated.
To avoid this dependency injection may be used.
Dependency injection is optional to keep compatibility with other libs.
It will allow to not trigger `jslib` imports and so local `jslib` is preserved.