### PR TITLE
feat: Add file encryption methods

### DIFF
--- a/src/WebVaultClient.spec.js
+++ b/src/WebVaultClient.spec.js
@@ -3,6 +3,7 @@ import { Utils } from './@bitwarden/jslib/misc/utils'
 import fs from 'fs'
 import path from 'path'
 import range from 'lodash/range'
+import { SymmetricCryptoKey } from './@bitwarden/jslib/models/domain/symmetricCryptoKey'
 
 jest.spyOn(Utils, 'init').mockImplementation(() => {})
 
@@ -346,6 +347,28 @@ describe('WebVaultClient', () => {
         0,
         123456
       )
+    })
+  })
+
+  describe('decryptEncryptionKey', () => {
+    const client = new WebVaultClient('https://me.cozy.wtf')
+    jest
+      .spyOn(client.cryptoService, 'decryptToBytes')
+      .mockResolvedValue(new ArrayBuffer(64))
+    jest
+      .spyOn(client, 'getEncryptionKey')
+      .mockResolvedValue(new SymmetricCryptoKey(new ArrayBuffer(64)))
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should decrypt the given key with correct length', async () => {
+      const encryptedKey = 'xyz'
+      const key = await client.decryptEncryptionKey(encryptedKey)
+      expect(key.key.byteLength).toBe(64)
+      expect(key.encType).toBe(2)
+      expect(key.encKey.byteLength).toBe(32)
     })
   })
 })


### PR DESCRIPTION
This adds methods in order to encrypt/decrypt binary files

A notable difference with bitwarden's ciphers is that we need to generate new
encryption keys: all the ciphers are encrypted with the the same vault
encryption key, while we want a specific encryption key for each
encrypted directory.