### PR TITLE
fix: call `cryptoService.makeKey` directly form `computeMasterKey`

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -463,15 +463,12 @@ class WebVaultClient {
    * @return {string} hashed password for login
    */
   async computeMasterKey(masterPassword, iterations, kdf) {
-    // clone the authService to avoid messing
-    // with the requested kdf and kdf iterations if provided
-    let authService = iterations
-      ? this.authService
-      : Object.assign(Object.create(this.authService), this.authService, {
-          kdfIterations: iterations,
-          kdf: kdf || KdfType.PBKDF2_SHA256
-        })
-    return await authService.makePreloginKey(masterPassword, this.email)
+    return await this.cryptoService.makeKey(
+      masterPassword,
+      this.email,
+      kdf || KdfType.PBKDF2_SHA256,
+      iterations
+    )
   }
 
   /**

--- a/src/WebVaultClient.spec.js
+++ b/src/WebVaultClient.spec.js
@@ -327,4 +327,25 @@ describe('WebVaultClient', () => {
       })
     })
   })
+
+  describe('computeMasterKey', () => {
+    const client = new WebVaultClient('https://me.cozy.wtf')
+
+    jest.spyOn(client.cryptoService, 'makeKey').mockImplementation(() => {})
+
+    afterEach(() => {
+      client.cryptoService.makeKey.mockReset()
+    })
+
+    it('should call cryptoService.makeKey', async () => {
+      await client.computeMasterKey('SOME_PASSWORD', 123456, 0)
+
+      expect(client.cryptoService.makeKey).toHaveBeenCalledWith(
+        'SOME_PASSWORD',
+        'me@me.cozy.wtf',
+        0,
+        123456
+      )
+    })
+  })
 })


### PR DESCRIPTION
Previous version introduced unnecessary complexity as `kdfIterations` and `kdf` were ignored by `authService.makePreloginKey()`

Also the `iterations` handling did not work correctly as the ternary operator was reversed

As the only value of `authService.makePreloginKey()` is to query `kdfIterations` and `kdf` and because we never call `computeMasterKey()` with those values unset, then we call `cryptoService.makeKey()` directly