### PR TITLE
feat: Use isPassContext flag to check if extension is installed

### DIFF
--- a/src/WebVaultClient.js
+++ b/src/WebVaultClient.js
@@ -94,11 +94,12 @@ class WebVaultClient {
    * @param {string} options.urls.identity - URL of the identity server
    * @param {string} options.urls.api - URL of the api server
    * @param {string} options.urls.events - URL of the events server
+   * @param {boolean} options.isPassContext - Whether or not this is used in a Pass context
    * @param {VaultData} vaultData - optional Vault related services that may be injected
    */
   constructor(
     instance_or_email,
-    { urls, locale, unsafeStorage } = {},
+    { urls, locale, unsafeStorage, isPassContext = true } = {},
     vaultData = undefined
   ) {
     this.instance = instance_or_email
@@ -113,6 +114,7 @@ class WebVaultClient {
     }
 
     this.locale = locale || 'en'
+    this.isPassContext = isPassContext
     this.init({ unsafeStorage }, vaultData)
   }
 

--- a/src/components/defaults.js
+++ b/src/components/defaults.js
@@ -1,7 +1,11 @@
 import { checkHasInstalledExtension } from '../CozyUtils'
 
 export const checkShouldUnlock = async (vaultClient, client) => {
-  return (
-    (await checkHasInstalledExtension(client)) && (await vaultClient.isLocked())
-  )
+  if (vaultClient.isPassContext) {
+    return (
+      (await checkHasInstalledExtension(client)) &&
+      (await vaultClient.isLocked())
+    )
+  }
+  return vaultClient.isLocked()
 }

--- a/src/components/defaults.spec.js
+++ b/src/components/defaults.spec.js
@@ -1,0 +1,48 @@
+import { checkHasInstalledExtension } from '../CozyUtils'
+import { checkShouldUnlock } from './defaults'
+import WebVaultClient from '../WebVaultClient'
+
+jest.mock('../CozyUtils', () => ({
+  checkHasInstalledExtension: jest.fn(),
+  getEmail: jest.fn().mockReturnValue('me@test.fr'),
+  isInstance: jest.fn().mockReturnValue(true)
+}))
+
+describe('checkShouldUnlock', () => {
+  const client = {}
+
+  it('should unlock if extension is installed and locked', async () => {
+    const vaultClient = new WebVaultClient('https://me.cozy.wtf')
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(true)
+    checkHasInstalledExtension.mockReturnValue(true)
+
+    const shouldUnlock = await checkShouldUnlock(vaultClient, client)
+    expect(shouldUnlock).toBe(true)
+  })
+
+  it('should not unlock if extension is installed and unlocked', async () => {
+    const vaultClient = new WebVaultClient('https://me.cozy.wtf')
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(false)
+    checkHasInstalledExtension.mockReturnValue(true)
+    const shouldUnlock = await checkShouldUnlock(vaultClient, client)
+    expect(shouldUnlock).toBe(false)
+  })
+
+  it('should unlock if vault is unlocked and not in a pass context', async () => {
+    const vaultClient = new WebVaultClient('https://me.cozy.wtf', {
+      isPassContext: false
+    })
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(true)
+    const shouldUnlock = await checkShouldUnlock(vaultClient, client)
+    expect(shouldUnlock).toBe(true)
+  })
+
+  it('should not unlock if vault is unlocked and not in a pass context', async () => {
+    const vaultClient = new WebVaultClient('https://me.cozy.wtf', {
+      isPassContext: false
+    })
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(false)
+    const shouldUnlock = await checkShouldUnlock(vaultClient, client)
+    expect(shouldUnlock).toBe(false)
+  })
+})

--- a/src/components/vaultUnlockContext.spec.jsx
+++ b/src/components/vaultUnlockContext.spec.jsx
@@ -59,7 +59,8 @@ describe('vault unlock context', () => {
 
   it('should not show unlock form and call onUnlock if extension is not installed', async () => {
     useVaultClient.mockReturnValue({
-      isLocked: jest.fn().mockResolvedValue(true)
+      isLocked: jest.fn().mockResolvedValue(true),
+      isPassContext: true
     })
     checkHasInstalledExtension.mockResolvedValue(false)
     const { root, onUnlock } = await setup()
@@ -69,7 +70,8 @@ describe('vault unlock context', () => {
 
   it('should not show unlock form and call onUnlock if vault is unlocked', async () => {
     useVaultClient.mockReturnValue({
-      isLocked: jest.fn().mockResolvedValue(false)
+      isLocked: jest.fn().mockResolvedValue(false),
+      isPassContext: true
     })
     checkHasInstalledExtension.mockResolvedValue(true)
     const { root, onUnlock } = await setup()


### PR DESCRIPTION
In a pass context, we want to check if a Pass client is installed, e.g.
the browser extension, the mobile app or the web cozy-pass client. This
check is useful to know whether or not the unlock vault form should be
displayed to the user.

But in other context, such as Drive client-side encryption, this check
is not required at all.