### PR TITLE
feat: Allow passing client as props in VaultContext

### DIFF
--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -15,7 +15,7 @@ class VaultProvider extends React.Component {
     super(props)
 
     this.state = {
-      client: this.props.client,
+      vaultClient: this.props.vaultClient,
       locked: true
     }
 
@@ -28,18 +28,18 @@ class VaultProvider extends React.Component {
   }
 
   componentWillUnmount() {
-    const { client } = this.state
-    if (!client) {
+    const { vaultClient } = this.state
+    if (!vaultClient) {
       return
     }
-    client.removeListener('unlock', this.updateLockedState)
-    client.removeListener('lock', this.updateLockedState)
-    client.removeListener('login', this.updateLockedState)
+    vaultClient.removeListener('unlock', this.updateLockedState)
+    vaultClient.removeListener('lock', this.updateLockedState)
+    vaultClient.removeListener('login', this.updateLockedState)
   }
 
   async updateLockedState() {
-    const { client } = this.state
-    const locked = await client.isLocked()
+    const { vaultClient } = this.state
+    const locked = await vaultClient.isLocked()
     if (locked != this.state.locked) {
       this.setState({ locked })
     }
@@ -47,32 +47,32 @@ class VaultProvider extends React.Component {
 
   setupClient() {
     const unsafeStorage = this.props.unsafeStorage
-    const client =
-      this.props.client ||
+    const vaultClient =
+      this.props.vaultClient ||
       getVaultClient(this.props.instance, unsafeStorage, this.props.vaultData)
 
     this.setState(
       {
-        client,
+        vaultClient,
         locked: true
       },
       () => {
-        client.on('unlock', this.updateLockedState)
-        client.on('lock', this.updateLockedState)
-        client.on('login', this.updateLockedState)
+        vaultClient.on('unlock', this.updateLockedState)
+        vaultClient.on('lock', this.updateLockedState)
+        vaultClient.on('login', this.updateLockedState)
 
         this.updateLockedState()
       }
     )
 
     if (this.props.setClient) {
-      this.props.setClient(client)
+      this.props.setClient(vaultClient)
     }
   }
 
   render() {
-    const { client } = this.state
-    return client ? (
+    const { vaultClient } = this.state
+    return vaultClient ? (
       <VaultContext.Provider value={this.state}>
         {this.props.children}
       </VaultContext.Provider>
@@ -82,7 +82,7 @@ class VaultProvider extends React.Component {
 
 VaultProvider.propTypes = {
   instance: PropTypes.string,
-  client: PropTypes.object,
+  vaultClient: PropTypes.object,
   unsafeStorage: PropTypes.bool,
   setClient: PropTypes.func
 }
@@ -90,7 +90,9 @@ VaultProvider.propTypes = {
 const withVaultClient = BaseComponent => {
   const Component = props => (
     <VaultContext.Consumer>
-      {({ client }) => <BaseComponent vaultClient={client} {...props} />}
+      {({ vaultClient }) => (
+        <BaseComponent vaultClient={vaultClient} {...props} />
+      )}
     </VaultContext.Consumer>
   )
 
@@ -102,7 +104,7 @@ const withVaultClient = BaseComponent => {
 
 const useVaultClient = () => {
   const ctx = useContext(VaultContext)
-  return ctx.client
+  return ctx.vaultClient
 }
 
 export { VaultContext, VaultProvider, withVaultClient, useVaultClient }

--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -14,8 +14,16 @@ class VaultProvider extends React.Component {
   constructor(props) {
     super(props)
 
+    let vaultClient = this.props.vaultClient
+    if (this.props.client) {
+      vaultClient = this.props.client
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Passing client in props is deprecated, please use vaultClient instead.'
+      )
+    }
     this.state = {
-      vaultClient: this.props.vaultClient,
+      vaultClient: vaultClient,
       locked: true
     }
 
@@ -83,6 +91,7 @@ class VaultProvider extends React.Component {
 VaultProvider.propTypes = {
   instance: PropTypes.string,
   vaultClient: PropTypes.object,
+  client: PropTypes.object, // deprecated
   unsafeStorage: PropTypes.bool,
   setClient: PropTypes.func
 }

--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -15,7 +15,7 @@ class VaultProvider extends React.Component {
     super(props)
 
     this.state = {
-      client: null,
+      client: this.props.client,
       locked: true
     }
 
@@ -24,9 +24,7 @@ class VaultProvider extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.instance) {
-      this.setupClient()
-    }
+    this.setupClient()
   }
 
   componentWillUnmount() {
@@ -49,12 +47,9 @@ class VaultProvider extends React.Component {
 
   setupClient() {
     const unsafeStorage = this.props.unsafeStorage
-
-    const client = getVaultClient(
-      this.props.instance,
-      unsafeStorage,
-      this.props.vaultData
-    )
+    const client =
+      this.props.client ||
+      getVaultClient(this.props.instance, unsafeStorage, this.props.vaultData)
 
     this.setState(
       {
@@ -86,7 +81,8 @@ class VaultProvider extends React.Component {
 }
 
 VaultProvider.propTypes = {
-  instance: PropTypes.string.isRequired,
+  instance: PropTypes.string,
+  client: PropTypes.object,
   unsafeStorage: PropTypes.bool,
   setClient: PropTypes.func
 }

--- a/src/components/VaultContext.spec.jsx
+++ b/src/components/VaultContext.spec.jsx
@@ -21,26 +21,32 @@ describe('VaultProvider', () => {
       </VaultProvider>
     )
 
-    const client = component.state('client')
+    const vaultClient = component.state('vaultClient')
 
-    expect(ChildComponent).toHaveBeenCalledWith({ client, locked: true })
+    expect(ChildComponent).toHaveBeenCalledWith({ vaultClient, locked: true })
 
-    client.unlock()
+    vaultClient.unlock()
 
     await new Promise(resolve =>
       setTimeout(() => {
         expect(ChildComponent).toHaveBeenCalledTimes(2)
-        expect(ChildComponent).toHaveBeenCalledWith({ client, locked: false })
+        expect(ChildComponent).toHaveBeenCalledWith({
+          vaultClient,
+          locked: false
+        })
         resolve()
       })
     )
 
-    client.lock()
+    vaultClient.lock()
 
     await new Promise(resolve =>
       setTimeout(() => {
         expect(ChildComponent).toHaveBeenCalledTimes(3)
-        expect(ChildComponent).toHaveBeenCalledWith({ client, locked: true })
+        expect(ChildComponent).toHaveBeenCalledWith({
+          vaultClient,
+          locked: true
+        })
         resolve()
       })
     )

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -27,7 +27,7 @@ const VaultUnlocker = ({
   checkShouldUnlock
 }) => {
   const cozyClient = useClient()
-  const { locked, client: vaultClient } = useContext(VaultContext)
+  const { locked, vaultClient } = useContext(VaultContext)
 
   const [showSpinner, setShowSpinner] = useState(false)
   const [isChecking, setIsChecking] = useState(true)

--- a/src/index.js
+++ b/src/index.js
@@ -18,3 +18,4 @@ export {
   VaultUnlockProvider,
   withVaultUnlockContext
 } from './components/vaultUnlockContext'
+export { UnlockForm } from './components/UnlockForm'


### PR DESCRIPTION
It can be useful to pass an initialized client to VaultContext
in case it must be shared between react components and redux store.
This avoids ending up with several client instance, holding different
states.