### PR TITLE
feat: Do not force the extension installation check on unlock

### DIFF
--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -57,6 +57,7 @@ class VaultProvider extends React.Component {
     const unsafeStorage = this.props.unsafeStorage
     const vaultClient =
       this.props.vaultClient ||
+      this.props.client ||
       getVaultClient(this.props.instance, unsafeStorage, this.props.vaultData)
 
     this.setState(

--- a/src/components/VaultUnlocker.jsx
+++ b/src/components/VaultUnlocker.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
 import withLocales from 'cozy-ui/transpiled/react/I18n/withLocales'
-import { useClient } from 'cozy-client'
 
 import localesEn from '../locales/en.json'
 import localesFr from '../locales/fr.json'
@@ -24,9 +23,8 @@ const VaultUnlocker = ({
   closable,
   onUnlock,
   UnlockForm,
-  checkShouldUnlock
+  addCheckShouldUnlock
 }) => {
-  const cozyClient = useClient()
   const { locked, vaultClient } = useContext(VaultContext)
 
   const [showSpinner, setShowSpinner] = useState(false)
@@ -42,7 +40,10 @@ const VaultUnlocker = ({
 
   useEffect(() => {
     const doCheckShouldUnlock = async () => {
-      const shouldUnlock = await checkShouldUnlock(vaultClient, cozyClient)
+      const shouldUnlock = await checkShouldUnlock(
+        vaultClient,
+        addCheckShouldUnlock
+      )
 
       setShouldUnlock(shouldUnlock)
       setIsChecking(false)
@@ -75,12 +76,12 @@ const VaultUnlocker = ({
 VaultUnlocker.propTypes = {
   onDismiss: PropTypes.func.isRequired,
   closable: PropTypes.bool,
-  onUnlock: PropTypes.func.isRequired
+  onUnlock: PropTypes.func.isRequired,
+  addCheckShouldUnlock: PropTypes.func
 }
 
 VaultUnlocker.defaultProps = {
-  UnlockForm,
-  checkShouldUnlock: checkShouldUnlock
+  UnlockForm
 }
 
 export default withLocales(locales)(VaultUnlocker)

--- a/src/components/defaults.js
+++ b/src/components/defaults.js
@@ -1,7 +1,13 @@
-import { checkHasInstalledExtension } from '../CozyUtils'
-
-export const checkShouldUnlock = async (vaultClient, client) => {
-  return (
-    (await checkHasInstalledExtension(client)) && (await vaultClient.isLocked())
-  )
+/**
+ * Check whether or not the vault should be unlocked
+ *
+ * @param {object} vaultClient - The vault client
+ * @param {function} addCheckShouldUnlock - An additional check method to unlock
+ * @returns {boolean} True if the vault should be unlocked
+ */
+export const checkShouldUnlock = async (
+  vaultClient,
+  addCheckShouldUnlock = () => true
+) => {
+  return (await addCheckShouldUnlock()) && (await vaultClient.isLocked())
 }

--- a/src/components/defaults.spec.js
+++ b/src/components/defaults.spec.js
@@ -1,0 +1,34 @@
+import { checkShouldUnlock } from './defaults'
+import WebVaultClient from '../WebVaultClient'
+
+jest.mock('../CozyUtils', () => ({
+  checkHasInstalledExtension: jest.fn(),
+  getEmail: jest.fn().mockReturnValue('me@test.fr'),
+  isInstance: jest.fn().mockReturnValue(true)
+}))
+
+describe('checkShouldUnlock', () => {
+  const vaultClient = new WebVaultClient('https://me.cozy.wtf')
+
+  it('should return true when the vault is locked', async () => {
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(true)
+    const shouldUnlock = await checkShouldUnlock(vaultClient)
+    expect(shouldUnlock).toBe(true)
+  })
+
+  it('should return false when the vault is already unlocked', async () => {
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(false)
+    const shouldUnlock = await checkShouldUnlock(vaultClient)
+    expect(shouldUnlock).toBe(false)
+  })
+
+  it('should return false when additional check function return false', async () => {
+    jest.spyOn(vaultClient, 'isLocked').mockResolvedValue(true)
+    const additionalUnlockCheck = () => false
+    const shouldUnlock = await checkShouldUnlock(
+      vaultClient,
+      additionalUnlockCheck
+    )
+    expect(shouldUnlock).toBe(false)
+  })
+})

--- a/src/components/vaultUnlockContext.jsx
+++ b/src/components/vaultUnlockContext.jsx
@@ -1,6 +1,4 @@
 import React, { useMemo, useState, useContext } from 'react'
-import { useClient } from 'cozy-client'
-
 import { useVaultClient } from './VaultContext'
 import { checkShouldUnlock } from './defaults'
 
@@ -42,8 +40,7 @@ export const useVaultUnlockContext = () => {
  * </VaultProvider>
  * ```
  */
-export const VaultUnlockProvider = ({ children, checkShouldUnlock }) => {
-  const client = useClient()
+export const VaultUnlockProvider = ({ children, addCheckShouldUnlock }) => {
   const vaultClient = useVaultClient()
   const [showingUnlockForm, setShowingUnlockForm] = useState(false)
   const [unlockFormProps, setUnlockFormProps] = useState(null)
@@ -64,7 +61,10 @@ export const VaultUnlockProvider = ({ children, checkShouldUnlock }) => {
         unlockFormProps.onDismiss && unlockFormProps.onDismiss()
       }
 
-      const shouldUnlock = await checkShouldUnlock(vaultClient, client)
+      const shouldUnlock = await checkShouldUnlock(
+        vaultClient,
+        addCheckShouldUnlock
+      )
 
       if (shouldUnlock) {
         setUnlockFormProps({
@@ -84,23 +84,13 @@ export const VaultUnlockProvider = ({ children, checkShouldUnlock }) => {
       unlockFormProps,
       vaultClient
     }
-  }, [
-    showingUnlockForm,
-    unlockFormProps,
-    vaultClient,
-    checkShouldUnlock,
-    client
-  ])
+  }, [showingUnlockForm, unlockFormProps, vaultClient, addCheckShouldUnlock])
 
   return (
     <vaultUnlockContext.Provider value={value}>
       {children}
     </vaultUnlockContext.Provider>
   )
-}
-
-VaultUnlockProvider.defaultProps = {
-  checkShouldUnlock: checkShouldUnlock
 }
 
 export const withVaultUnlockContext = Component => {

--- a/src/components/vaultUnlockContext.spec.jsx
+++ b/src/components/vaultUnlockContext.spec.jsx
@@ -4,15 +4,10 @@ import {
   VaultUnlockProvider,
   useVaultUnlockContext
 } from './vaultUnlockContext'
-import { checkHasInstalledExtension } from '../CozyUtils'
 import { useVaultClient } from './VaultContext'
 
 jest.mock('./VaultContext', () => ({
   useVaultClient: jest.fn()
-}))
-
-jest.mock('../CozyUtils', () => ({
-  checkHasInstalledExtension: jest.fn()
 }))
 
 describe('vault unlock context', () => {
@@ -51,27 +46,15 @@ describe('vault unlock context', () => {
     useVaultClient.mockReturnValue({
       isLocked: jest.fn().mockResolvedValue(true)
     })
-    checkHasInstalledExtension.mockResolvedValue(true)
     const { root, onUnlock } = await setup()
     root.getByText('showingUnlockForm: true')
     expect(onUnlock).not.toHaveBeenCalled()
-  })
-
-  it('should not show unlock form and call onUnlock if extension is not installed', async () => {
-    useVaultClient.mockReturnValue({
-      isLocked: jest.fn().mockResolvedValue(true)
-    })
-    checkHasInstalledExtension.mockResolvedValue(false)
-    const { root, onUnlock } = await setup()
-    expect(root.getByText('showingUnlockForm: false')).toBeTruthy()
-    expect(onUnlock).toHaveBeenCalled()
   })
 
   it('should not show unlock form and call onUnlock if vault is unlocked', async () => {
     useVaultClient.mockReturnValue({
       isLocked: jest.fn().mockResolvedValue(false)
     })
-    checkHasInstalledExtension.mockResolvedValue(true)
     const { root, onUnlock } = await setup()
     expect(root.getByText('showingUnlockForm: false')).toBeTruthy()
     expect(onUnlock).toHaveBeenCalled()


### PR DESCRIPTION
We used to check if a bitwarden client was installed when checking if the vault has to be unlocked. This is notably useful to harvest, that should not display the vault form if no pass client is used.
But this check is not always relevant, typically, it is not useful for the incoming Drive folder encryption. Therefore, we only check if the vault is locked by default, and let the possibility to define a function in props to add any check the app might want to do.

Note this includes a breaking change, described in 5df51a9