### PR TITLE
fix: Remove broken UnlockForm export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,4 +18,3 @@ export {
   VaultUnlockProvider,
   withVaultUnlockContext
 } from './components/vaultUnlockContext'
-export { UnlockForm } from './components/UnlockForm'


### PR DESCRIPTION
Since cc8f07932ca400afce1d82f3d73c27f6bfe28074, the UnlockForm is
exported. However, this was wrongly exported as it is default exported
in the component. Thus, this cannot work and triggers a warning in apps
using the lib such as Drive: `export 'UnlockForm' was not found`.
Consequently, we remove this useless export