### PR TITLE
fix: Use @cozy/minilog

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,13 +69,13 @@
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
     "@aspnet/signalr-protocol-msgpack": "^1.1.0",
+    "@cozy/minilog": "^1.0.0",
     "big-integer": "^1.6.44",
     "classnames": "^2.2.6",
     "cozy-device-helper": "^1.7.5",
     "lodash": "^4.17.15",
     "lunr": "^2.3.6",
     "microee": "^0.0.6",
-    "minilog": "https://github.com/cozy/minilog.git#master",
     "node-forge": "^0.9.0",
     "papaparse": "^5.1.1",
     "prop-types": "^15.7.2",
@@ -85,8 +85,8 @@
   },
   "peerDependencies": {
     "cozy-client": "^16.10.2",
-    "cozy-ui": "^42.3.0",
     "cozy-flags": "^2.6.0",
+    "cozy-ui": "^42.3.0",
     "react": "^16.8.3",
     "react-dom": "^16.9.0"
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,4 @@
-import minilogLib from 'minilog'
+import minilogLib from '@cozy/minilog'
 
 const minilog =
   typeof window !== 'undefined' && window.minilog ? window.minilog : minilogLib

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,7 +1365,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cozy/minilog@1.0.0":
+"@cozy/minilog@1.0.0", "@cozy/minilog@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@cozy/minilog/-/minilog-1.0.0.tgz#1acc1aad849261e931e255a5f181b638315f7b84"
   integrity sha512-IkDHF9CLh0kQeSEVsou59ar/VehvenpbEUjLfwhckJyOUqZnKAWmXy8qrBgMT5Loxr8Xjs2wmMnj0D67wP00eQ==
@@ -7056,12 +7056,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-"minilog@https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
 
 minimatch@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
The old alias to cozy git repo breaks build in other apps (eg bank)

I will then need to cherrypick on 3.8.1 and publish 3.8.1 for bank to use