### PR TITLE
chore(github): Add dependabot config and automerge

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,8 @@
+minApprovals:
+  MEMBER: 1
+requiredLabels:
+- merge
+reportStatus: true
+blockingChecks:
+  status: 'pending'
+mergeMethod: rebase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    commit-message:
+      # Prefix all commit messages with "fix"
+      prefix: "fix"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This will prevent dependabot update during weekdays

This will allow PR to be automerge when label merge added