### PR TITLE
fix: Setup client when init with cozy-client instance

### DIFF
--- a/src/components/VaultContext.jsx
+++ b/src/components/VaultContext.jsx
@@ -39,6 +39,8 @@ class VaultProvider extends React.Component {
         cozyClient.on('login', () => {
           this.setupClient(cozyClient.getStackClient().uri)
         })
+      } else {
+        this.setupClient(uri)
       }
     }
     if (instance) {


### PR DESCRIPTION
A cozy-client instance can be passed to the vault, so it can
be setup based on the client URL once it is logged. However,
the setup was never done when the login was already done and the
URL already provided.