### PR TITLE
fix: Handle Amirale App UI update

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-preset-cozy-app": "^1.6.0",
     "cozy-client": "^16.10.2",
     "cozy-flags": "2.6.0",
+    "cozy-intent": "^2.0.2",
     "cozy-ui": "^42.3.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
@@ -86,6 +87,7 @@
   "peerDependencies": {
     "cozy-client": "^16.10.2",
     "cozy-flags": "^2.6.0",
+    "cozy-intent": "^2.0.2",
     "cozy-ui": "^42.3.0",
     "react": "^16.8.3",
     "react-dom": "^16.9.0"

--- a/src/components/UnlockForm.jsx
+++ b/src/components/UnlockForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useEffect } from 'react'
 import cx from 'classnames'
 import get from 'lodash/get'
 import PropTypes from 'prop-types'
@@ -13,6 +13,7 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import { IllustrationDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import KeychainIcon from 'cozy-ui/transpiled/react/Icons/Keychain'
+import { useWebviewIntent } from 'cozy-intent'
 
 import CloudIcon from './IconCozySecurity'
 import PasswordField from './PasswordField'
@@ -76,6 +77,31 @@ const UnlockForm = props => {
   ])
 
   const canAuthWithOIDC = canClientAuthWithOIDC(client)
+
+  const webviewIntent = useWebviewIntent()
+
+  useEffect(() => {
+    webviewIntent &&
+      webviewIntent.call(
+        'setFlagshipUI',
+        {
+          bottomTheme: 'light',
+          topTheme: 'light'
+        },
+        'cozy-keys-lib/UnlockForm'
+      )
+
+    return () =>
+      webviewIntent &&
+      webviewIntent.call(
+        'setFlagshipUI',
+        {
+          bottomTheme: 'light',
+          topTheme: 'light'
+        },
+        'cozy-keys-lib/UnlockForm'
+      )
+  }, [webviewIntent])
 
   return (
     <CozyTheme variant="inverted">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4035,6 +4035,13 @@ cozy-flags@2.6.0:
   dependencies:
     microee "^0.0.6"
 
+cozy-intent@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cozy-intent/-/cozy-intent-2.0.2.tgz#81330389c7b8cfc1433608a435873b362691931c"
+  integrity sha512-E+9WqbYhFiV/KCGFArSJu/jcvdliI58Vfa3ajrJFRV2AsPtej6wN5qfn6Wex53xpdTAZSjLfmYAQLNt0cl6xGw==
+  dependencies:
+    post-me "0.4.5"
+
 cozy-interapp@0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
@@ -8840,6 +8847,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+post-me@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/post-me/-/post-me-0.4.5.tgz#6171b721c7b86230c51cfbe48ddea047ef8831ce"
+  integrity sha512-XgPdktF/2M5jglgVDULr9NUb/QNv3bY3g6RG22iTb5MIMtB07/5FJB5fbVmu5Eaopowc6uZx7K3e7x1shPwnXw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# Description

Currently, opening the UnlockForm on HomePage in Amirale App will trigger the icons to black. Instead, we want them to be white. This lib has to be updated.

Fixes [# (issue)](https://trello.com/c/nFvqeznK/402-corriger-les-status-bar-nav-bar-sur-lensemble-des-%C3%A9crans)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested manually only, in local dev env. Physical and emulated Android device.

- [x] Icons are white on UnlockForm opening
- [x] Icons stay white on UnlockForm closing

# Checklist:

- [x] I have performed a self-review of my code
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~